### PR TITLE
Autoplay policy patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 5.0.0   
 **Tested up to:** 5.5.1   
 **Requires PHP:** 7.1   
-**Stable tag:** 2.0.5
+**Stable tag:** 2.0.6  
 **License:** CC BY-ND 4.0   
 **License URI:** https://creativecommons.org/licenses/by-nd/4.0  
 **GitHub:** https://github.com/AgoraIO/Agora-Word-Press  

--- a/public/js/wp-agora-io-public.js
+++ b/public/js/wp-agora-io-public.js
@@ -387,7 +387,23 @@ window.AGORA_UTILS = {
       )
     );
 
-    remoteStream.play('agora_remote_' + streamId);
+    remoteStream.play('agora_remote_' + streamId, function(err){
+      if (err && err.status !== "aborted"){
+        console.log('Remote stream:' + streamId + ' failed to autoplay. Playing muted. Tap <video> container to enable audio.' );
+        remoteStream.stop();
+        window.AGORA_UTILS.toggleVisibility('#' + streamId + '_mute', true);
+        remoteStream.play('agora_remote_' + streamId, { muted: true });
+        // The playback fails. Guide the user to resume the playback by clicking.            
+        document.getElementById(streamId + '_container').onclick = playWithAudio; 
+        function playWithAudio() {
+          console.log('Attempting to play remote stream:' + streamId + ' with audio after user interaction' );
+          remoteStream.stop();
+          window.AGORA_UTILS.toggleVisibility('#' + streamId + '_mute', false);
+          remoteStream.play('agora_remote_' + streamId, { muted: false });
+          document.getElementById(streamId + '_container').removeEventListener('click', playWithAudio)
+        }     
+      }
+    });
   },
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: live streaming, video streaming, video call, video conference
 Requires at least: 5.0
 Tested up to: 5.5.1
 Requires PHP: 7.1
-Stable tag: 2.0.5
+Stable tag: 2.0.6
 Donate link:
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -157,6 +157,9 @@ Resolves an issue with certain frameworks not enquing the RTC SDK correctly in a
 Version 2.0.5
 Add a waiting time before total disconnect on Audience views and wait for broadcaster reconnection.
 
+Version 2.0.6
+Adds a patch for autoplay policy issues. When remote user joins, if browser autoplay policy blocks video with audio playback, the video will play without audio and the mute icon will appear. The user will need to click each remote video to enable the audio. The requirement for clicking each stream is to support Safari which has the strictest autoplay policy.
+
 == Frequently Asked Questions ==
 #1.  Why don't my project credentials (App ID and App Certificate) get saved when I input them on the Settings tab? 
 
@@ -184,5 +187,5 @@ Add a waiting time before total disconnect on Audience views and wait for broadc
   Browsers require a secure connection (HTTPS) for accessing a device's microphone and camera. When testing locally, localhost is a whitelisted URL but once you deploy to production you will need to have a secure connection for the plugin to function properly.
 
 == Upgrade Notice ==
-[Minor Update] Version 2.0.4 patch fixes issue with RTC in audience mode.
+[Minor Update] Version 2.0.6 patch fixes issue with browser autoplay policy.
 ...

--- a/wp-agora-io.php
+++ b/wp-agora-io.php
@@ -11,7 +11,7 @@
  * Plugin Name:       WP Agora.io
  * Plugin URI:        https://github.com/digitallysavvy/Agora-Word-Press/
  * Description:       Integrate the Agora Communication and Streaming platform directly into your wordpress content. This plugin let you create channels and manage their settings directly into WP.
- * Version:           2.0.5
+ * Version:           2.0.6
  * Author:            Agora.io
  * Author URI:        https://www.agora.io
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version based on SemVer - https://semver.org
  */
-define( 'WP_AGORA_IO_VERSION', '2.0.5' );
+define( 'WP_AGORA_IO_VERSION', '2.0.6' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
Adds a patch for autoplay policy issues. When remote user joins, if browser autoplay policy blocks video with audio playback, the video will play without audio and the mute icon will appear. The user will need to click each remote video to enable the audio. The requirement for clicking each stream is to support Safari which has the strictest autoplay policy.