### PR TITLE
v2.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 **Contributors:** [jalamprea](https://github.com/jalamprea), [digitallysavvy](https://github.com/digitallysavvy)  
 **Tags:** live streaming, video streaming, video call, video conference  
 **Requires at least:** 5.0.0   
-**Tested up to:** 5.5.1   
+**Tested up to:** 5.6   
 **Requires PHP:** 7.1   
-**Stable tag:** 2.0.6  
+**Stable tag:** 2.0.7  
 **License:** CC BY-ND 4.0   
 **License URI:** https://creativecommons.org/licenses/by-nd/4.0  
 **GitHub:** https://github.com/AgoraIO/Agora-Word-Press  

--- a/public/css/wp-agora-styles.css
+++ b/public/css/wp-agora-styles.css
@@ -207,6 +207,7 @@
 .agora.agora-audience .screen-users-1 .user {
   height: 65vh;
   background-color: transparent;
+  pointer-events: all;
 }
 
 /* screeen with 2 users */

--- a/public/js/screen-share.js
+++ b/public/js/screen-share.js
@@ -1,6 +1,14 @@
-
+window.screenshareAvailable = false;
 window.screenClient = AgoraRTC.createClient({mode: 'rtc', codec: 'vp8'});
 window.screenshareClients = {}; // remote streams from screen shares
+window.screenClient.init(window.agoraAppId, function (e) {
+  AgoraRTC.Logger.info("AgoraRTC screenClient initialized", e);
+  window.screenshareAvailable = true;
+  // window.AGORA_SCREENSHARE_UTILS.joinChannelAsScreenShare(cb);
+}, function (err) {
+  AgoraRTC.Logger.error("[ERROR] : AgoraRTC screenClient init failed", err);
+  // cb(err, null);
+});
 
 window.AGORA_SCREENSHARE_UTILS = {
 
@@ -12,6 +20,11 @@ window.AGORA_SCREENSHARE_UTILS = {
   // SCREEN SHARING
   initScreenShare: function (cb) {
 
+    if (!window.screenshareAvailable) {
+      alert('Screenshare is not available!')
+      return;
+    }
+
     // TODO: Validate window.remoteStreams length !== 0 ?
     if (Object.keys(window.screenshareClients).length>0) {
       cb('Screen sharing in progress', null);
@@ -19,45 +32,59 @@ window.AGORA_SCREENSHARE_UTILS = {
       return;
     }
 
-    window.screenClient.init(window.agoraAppId, function (e) {
-      AgoraRTC.Logger.info("AgoraRTC screenClient initialized", e);
-      window.AGORA_SCREENSHARE_UTILS.joinChannelAsScreenShare(cb);
-    }, function (err) {
-      AgoraRTC.Logger.error("[ERROR] : AgoraRTC screenClient init failed", err);
-      cb(err, null);
-    });  
-  },
 
-  joinChannelAsScreenShare: function (cb) {
     const userId = null; // window.userID or set to null to auto generate uid on successfull connection
-    const successJoin = function(uid) {
+    
+    
+    // Create the stream for screen sharing.
+    const screenStream = AgoraRTC.createStream({
+      // streamID: uid,
+      audio: false, // Set the audio attribute as false to avoid any echo during the call.
+      video: false,
+      screen: true, // screen stream
+      screenAudio: true,
+      mediaSource:  'screen', // Firefox: 'screen', 'application', 'window' (select one)
+    });
 
-      if (window.AGORA_RTM_UTILS) {
-        const msg = {
-          description: undefined,
-          messageType: 'TEXT',
-          rawMessage: undefined,
-          text: `${uid}: start screen share`
+    screenStream.setScreenProfile(screenVideoProfile); // set the profile of the screen
+    screenStream.init(function successInit() {
+      AgoraRTC.Logger.info("getScreen successful");
+      window.localStreams.screen.stream = screenStream; // keep track of the screen stream
+
+      const successJoin = function(uid) {
+        console.log(' Full join', uid)
+        window.localStreams.screen.id = uid;  // keep track of the uid of the screen stream.
+        if (window.AGORA_RTM_UTILS) {
+          const msg = {
+            description: undefined,
+            messageType: 'TEXT',
+            rawMessage: undefined,
+            text: `${uid}: start screen share`
+          }
+          window.AGORA_RTM_UTILS.sendChannelMessage(msg);
         }
-        window.AGORA_RTM_UTILS.sendChannelMessage(msg);
-      }
 
-      window.localStreams.screen.id = uid;  // keep track of the uid of the screen stream.
-      
-      // Create the stream for screen sharing.
-      const screenStream = AgoraRTC.createStream({
-        streamID: uid,
-        audio: false, // Set the audio attribute as false to avoid any echo during the call.
-        video: false,
-        screen: true, // screen stream
-        screenAudio: true,
-        mediaSource:  'screen', // Firefox: 'screen', 'application', 'window' (select one)
-      });
-
-      screenStream.setScreenProfile(screenVideoProfile); // set the profile of the screen
-      screenStream.init(function successInit(){
-        AgoraRTC.Logger.info("getScreen successful");
-        window.localStreams.screen.stream = screenStream; // keep track of the screen stream
+        window.screenClient.on('stream-published', function (evt) {
+          AgoraRTC.Logger.info("Publish screen stream successfully");
+          // localStreams.camera.stream.muteVideo(); // disable the local video stream (will send a mute signal)
+          // localStreams.camera.stream.stop(); // stop playing the local stream
+          
+          // TODO: add logic to swap main video feed back from container
+          // debugger;
+          if (typeof mainStreamId !== 'undefined') {
+            remoteStreams[mainStreamId].stop(); // stop the main video stream playback
+            
+            if (window.AGORA_COMMUNICATION_CLIENT.addRemoteStreamView) {
+              window.AGORA_COMMUNICATION_CLIENT.addRemoteStreamView(remoteStreams[mainStreamId]); // send the main video stream to a container
+            }
+          }
+          // localStreams.screen.stream.play('full-screen-video'); // play the screen share as full-screen-video (vortext effect?)
+          // jQuery("#video-btn").prop("disabled",true); // disable the video button (as cameara video stream is disabled)
+        });
+        
+        window.screenClient.on('stopScreenSharing', function (evt) {
+          AgoraRTC.Logger.info("screen sharing stopped", err);
+        });
 
 
         window.screenClient.publish(screenStream, function (err) {
@@ -77,55 +104,35 @@ window.AGORA_SCREENSHARE_UTILS = {
         jQuery("#screen-share-btn").prop("disabled", false); // enable button
         window.screenShareActive = true;
         cb(null, true);
-      }, function errorInit(err) {
-        AgoraRTC.Logger.error("[ERROR] : getScreen failed", err);
-        window.localStreams.screen.id = ""; // reset screen stream id
-        window.localStreams.screen.stream = {}; // reset the screen stream
-        window.screenShareActive = false; // resest screenShare
+      };
+      const failedJoin = function(err) {
+        AgoraRTC.Logger.error("[ERROR] : join channel as screen-share failed", err);
         cb(err, null);
-        // window.AGORA_SCREENSHARE_UTILS.toggleScreenShareBtn(); // toggle the button icon back (will appear disabled)
-        if (err && err.info) {
-          alert('ScreenShare Error: ' + err.info);
+      };
+
+      window.AGORA_SCREENSHARE_UTILS.agora_generateAjaxToken(function(err, token) {
+        if (err) {
+          AgoraRTC.Logger.error("[TOKEN ERROR] : Get Token failed:", err);
+          cb(err, null);
+          return false;
         }
+
+        window.screenClient.join(token, window.channelName, userId, successJoin, failedJoin);
+
       });
-    };
-    const failedJoin = function(err) {
-      AgoraRTC.Logger.error("[ERROR] : join channel as screen-share failed", err);
+
+    }, function errorInit(err) {
+      AgoraRTC.Logger.error("[ERROR] : getScreen failed", err);
+      window.localStreams.screen.id = ""; // reset screen stream id
+      window.localStreams.screen.stream = {}; // reset the screen stream
+      window.screenShareActive = false; // resest screenShare
       cb(err, null);
-    };
-
-    window.AGORA_SCREENSHARE_UTILS.agora_generateAjaxToken(function(err, token) {
-      if (err) {
-        AgoraRTC.Logger.error("[TOKEN ERROR] : Get Token failed:", err);
-        cb(err, null);
-        return false;
+      // window.AGORA_SCREENSHARE_UTILS.toggleScreenShareBtn(); // toggle the button icon back (will appear disabled)
+      if (err && err.info) {
+        alert('ScreenShare Error: ' + err.info);
       }
-
-      window.screenClient.join(token, window.channelName, userId, successJoin, failedJoin);
-
     });
 
-    window.screenClient.on('stream-published', function (evt) {
-      AgoraRTC.Logger.info("Publish screen stream successfully");
-      // localStreams.camera.stream.muteVideo(); // disable the local video stream (will send a mute signal)
-      // localStreams.camera.stream.stop(); // stop playing the local stream
-      
-      // TODO: add logic to swap main video feed back from container
-      // debugger;
-      if (typeof mainStreamId !== 'undefined') {
-        remoteStreams[mainStreamId].stop(); // stop the main video stream playback
-        
-        if (window.AGORA_COMMUNICATION_CLIENT.addRemoteStreamView) {
-          window.AGORA_COMMUNICATION_CLIENT.addRemoteStreamView(remoteStreams[mainStreamId]); // send the main video stream to a container
-        }
-      }
-      // localStreams.screen.stream.play('full-screen-video'); // play the screen share as full-screen-video (vortext effect?)
-      // jQuery("#video-btn").prop("disabled",true); // disable the video button (as cameara video stream is disabled)
-    });
-    
-    window.screenClient.on('stopScreenSharing', function (evt) {
-      AgoraRTC.Logger.info("screen sharing stopped", err);
-    });
   },
 
   stopScreenShare: function (cb) {

--- a/public/js/screen-share.js
+++ b/public/js/screen-share.js
@@ -66,10 +66,7 @@ window.AGORA_SCREENSHARE_UTILS = {
 
         window.screenClient.on('stream-published', function (evt) {
           AgoraRTC.Logger.info("Publish screen stream successfully");
-          // localStreams.camera.stream.muteVideo(); // disable the local video stream (will send a mute signal)
-          // localStreams.camera.stream.stop(); // stop playing the local stream
           
-          // TODO: add logic to swap main video feed back from container
           // debugger;
           if (typeof mainStreamId !== 'undefined') {
             remoteStreams[mainStreamId].stop(); // stop the main video stream playback
@@ -78,14 +75,11 @@ window.AGORA_SCREENSHARE_UTILS = {
               window.AGORA_COMMUNICATION_CLIENT.addRemoteStreamView(remoteStreams[mainStreamId]); // send the main video stream to a container
             }
           }
-          // localStreams.screen.stream.play('full-screen-video'); // play the screen share as full-screen-video (vortext effect?)
-          // jQuery("#video-btn").prop("disabled",true); // disable the video button (as cameara video stream is disabled)
         });
         
         window.screenClient.on('stopScreenSharing', function (evt) {
           AgoraRTC.Logger.info("screen sharing stopped", err);
         });
-
 
         window.screenClient.publish(screenStream, function (err) {
           AgoraRTC.Logger.error("[ERROR] : publish screen stream error: " + err);

--- a/public/js/wp-agora-io-public.js
+++ b/public/js/wp-agora-io-public.js
@@ -375,6 +375,10 @@ window.AGORA_UTILS = {
     // append the remote stream template to #remote-streams
     const streamsContainer = jQuery('#screen-users');
 
+    // avoid duplicate users in case there are errors removing old users and rejoining
+    const old = streamsContainer.find(`#${streamId}_container`)
+    if (old && old[0]) { old[0].remove() }
+
     streamsContainer.append(
       jQuery('<div/>', {'id': streamId + '_container',  'class': 'user remote-stream-container'}).append(
         jQuery('<div/>', {'id': streamId + '_mute', 'class': 'mute-overlay'}).append(

--- a/readme.txt
+++ b/readme.txt
@@ -161,7 +161,7 @@ Version 2.0.6
 Adds a patch for autoplay policy issues. When remote user joins, if browser autoplay policy blocks video with audio playback, the video will play without audio and the mute icon will appear. The user will need to click each remote video to enable the audio. The requirement for clicking each stream is to support Safari which has the strictest autoplay policy.
 
 Version 2.0.7
-Resolves a issues with Screen Share (#95 , #96). Resolved an issue with black boxes (#91). Resolves CSS issue causing audience button to be hidden.
+Resolves issues with Screen Share (#95 , #96). Resolved an issue with black boxes (#91). Resolves CSS issue causing audience button to be hidden.
 - [91](https://github.com/AgoraIO/Agora-WordPress/issues/91) 
 - [95](https://github.com/AgoraIO/Agora-WordPress/issues/95) 
 - [96](https://github.com/AgoraIO/Agora-WordPress/issues/96) 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: jalejo08, hermesf
 Tags: live streaming, video streaming, video call, video conference
 Requires at least: 5.0
-Tested up to: 5.5.1
+Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 2.0.6
+Stable tag: 2.0.7
 Donate link:
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -160,6 +160,12 @@ Add a waiting time before total disconnect on Audience views and wait for broadc
 Version 2.0.6
 Adds a patch for autoplay policy issues. When remote user joins, if browser autoplay policy blocks video with audio playback, the video will play without audio and the mute icon will appear. The user will need to click each remote video to enable the audio. The requirement for clicking each stream is to support Safari which has the strictest autoplay policy.
 
+Version 2.0.7
+Resolves a issues with Screen Share (#95 , #96). Resolved an issue with black boxes (#91). Resolves CSS issue causing audience button to be hidden.
+- [91](https://github.com/AgoraIO/Agora-WordPress/issues/91) 
+- [95](https://github.com/AgoraIO/Agora-WordPress/issues/95) 
+- [96](https://github.com/AgoraIO/Agora-WordPress/issues/96) 
+
 == Frequently Asked Questions ==
 #1.  Why don't my project credentials (App ID and App Certificate) get saved when I input them on the Settings tab? 
 
@@ -187,5 +193,5 @@ Adds a patch for autoplay policy issues. When remote user joins, if browser auto
   Browsers require a secure connection (HTTPS) for accessing a device's microphone and camera. When testing locally, localhost is a whitelisted URL but once you deploy to production you will need to have a secure connection for the plugin to function properly.
 
 == Upgrade Notice ==
-[Minor Update] Version 2.0.6 patch fixes issue with browser autoplay policy.
+[Minor Update] Version 2.0.7 add compatibility for WP 5.6 and fixes Screen share issues.
 ...

--- a/wp-agora-io.php
+++ b/wp-agora-io.php
@@ -10,8 +10,8 @@
  * @wordpress-plugin
  * Plugin Name:       WP Agora.io
  * Plugin URI:        https://github.com/digitallysavvy/Agora-Word-Press/
- * Description:       Integrate the Agora Communication and Streaming platform directly into your wordpress content. This plugin let you create channels and manage their settings directly into WP.
- * Version:           2.0.6
+ * Description:       Integrate the Agora Communication and Streaming platform directly into your WordPress content. This plugin let you create channels and manage their settings directly into WP.
+ * Version:           2.0.7
  * Author:            Agora.io
  * Author URI:        https://www.agora.io
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version based on SemVer - https://semver.org
  */
-define( 'WP_AGORA_IO_VERSION', '2.0.6' );
+define( 'WP_AGORA_IO_VERSION', '2.0.7' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
- Implements an updated screen share to resolve issues with screen sharing (#95 , #96). 
- Implements a check when a user drops due to poor connection, then rejoins to use the existing video placeholder and resolves the issue with black boxes appearing. (#91)
- Added `pointer-events` to the plugin's CSS to resolve the issue with some themes setting pointer-events:none` and causes  the audience's "join" button to be disabled.